### PR TITLE
Fixed the cookie not appearing in the frontend... CORS is a great time :))))

### DIFF
--- a/EmployeeReimbursementSystem/ApiLayer/Program.cs
+++ b/EmployeeReimbursementSystem/ApiLayer/Program.cs
@@ -11,12 +11,14 @@ public class Program
 
         // Add CORS
         var angularCORSPolicy = "AllowAngularFE";
-        builder.Services.AddCors(options => {
+        builder.Services.AddCors(options => { // Why does this CORS policy let the cookie go to the frontend?
             options.AddPolicy(name: angularCORSPolicy, 
                 policy => { // Add CORS policy so we can consume API in angular frontend
-                    policy.WithOrigins("http://localhost:4200")
+                    policy.WithOrigins("https://localhost:4200")
                         .AllowAnyHeader()
-                        .AllowAnyMethod();
+                        .AllowAnyMethod()
+                        .AllowCredentials()
+                        .SetPreflightMaxAge(TimeSpan.MaxValue);
                 }
             );
         });

--- a/client/src/app/services/employee.service.ts
+++ b/client/src/app/services/employee.service.ts
@@ -25,7 +25,8 @@ export class EmployeeService {
     // Entry point for logging in
     var result: string = "";
     var loginUrl: string = this.employeeUrl + '/LoginEmployee';
-    return this.http.post(loginUrl, employee, {responseType: 'text'}).pipe(
+    // responseType & witCredentials are necessary for the cookie to appear in angular. Why... 
+    return this.http.post(loginUrl, employee, {responseType: 'text', withCredentials: true}).pipe(
       tap((sessionId: any) => console.log(`Login success with sessionId ${sessionId}`)),
       catchError(this.handleError<string>('login'))
     );


### PR DESCRIPTION
After exhaustively trying out different methods of getting/setting cookies in ASP.NET (and banging my head against a wall) the problem was with CORS + HTTPS all along. Nothing in how the cookies are being set or whatever. Need to launch angular with the --ssl flag to make it follow HTTPS. Cors policy needs to allow credentials & have the preflight age set. And in angular we need 'withCredentials' in our http post request... I did the same thing the first time but it didn't work. and now it works :)
tldr, have the right cors policy and make sure the domains are both https compliant.